### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/FalkorDB/falkordb-cli/security/code-scanning/1](https://github.com/FalkorDB/falkordb-cli/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow. Since none of the steps in this workflow require write access to the repository, the minimal required permission (following least-privilege principles) is `contents: read`. The best practice is to add this `permissions` block at the top level of the workflow file (immediately following the `name` directive and before `on`), so all jobs inherit it unless they override it. No changes to the jobs or steps themselves are necessary. The fix is to insert the following lines:

```yaml
permissions:
  contents: read
```

after the `name: CI` line near the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
