### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/FalkorDB/falkordb-cli/security/code-scanning/2](https://github.com/FalkorDB/falkordb-cli/security/code-scanning/2)

To address the issue, add a `permissions` block specifying minimal permissions required for CI jobs, ideally at the root level of the workflow so it applies to all jobs. Based on the workflow contents, `contents: read` is suitable as both jobs only read repository resources or upload artifacts (which does not require extra write permissions). The `permissions` block should be placed at the top level, just below `name: CI` and before other keys (`on`, `env`, etc.). No imports are required; only a YAML edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
